### PR TITLE
Updated patch endpoint for updating a beer's ABV

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ This endpoint allows users to update the ABV of a specific beer. The request obj
 - **PATCH** - Update Availability of a Beer:
   `/api/v1/cerebral_beers/beer/:name/:availability`
 
-This endpoint allows users to update the availability of a specific beer to true or false directly via URL, without the need for a request object. Valid requests will receive `Availability of [name] sucessfully updated!` in response.
+This endpoint allows users to update the availability of a specific beer to true or false. Valid requests will receive `Availability of [name] sucessfully updated!` in response.
 
 #### Example URL's:
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 [![Waffle.io - Columns and their card count](https://badge.waffle.io/flevenson/BuildYourOwnBackend.svg?columns=all)](https://waffle.io/flevenson/BuildYourOwnBackend)
 
-
 # Cerebral Beers :beers::beers::beers:
 
 **Table of Contents**
@@ -15,7 +14,8 @@
 ---
 
 :beer::beer::beer:
-## Beers 
+
+## Beers
 
 - **GET** - Get All Beers: `/api/v1/cerebral_beers/beer`
 
@@ -51,6 +51,24 @@ This endpoint will return an array of all Cerebral beers, current and passed.
 
 ---
 
+- **GET** - Get All Currently Available Beers: `/api/v1/cerebral_beers/currently_available/:availability`
+
+This endpoint will return all currently available beers.
+
+```
+'/api/v1/cerebral_beers/currently_available/true'
+
+```
+
+All previously available beers may be retieved:
+
+```
+'/api/v1/cerebral_beers/currently_available/false'
+
+```
+
+---
+
 - **POST** - Add a Beer: `/api/v1/cerebral_beers/beer`
 
 This endpoint allows users to add a new beer. A beer may not be added if its style is not already in the database. The request object requires `name`, `description`, `abv`, `is_available` and `style` properties. Valid posts will receive `Beer successfully added!` in response.
@@ -69,23 +87,26 @@ This endpoint allows users to add a new beer. A beer may not be added if its sty
 
 ---
 
-- **PATCH** - Update Availability and ABV of a Beer:
-  `/api/v1/cerebral_beers/beer/:name/:availability/:abv`
+- **PATCH** - Update ABV of a Beer:
+  `/api/v1/cerebral_beers/beer/`
 
-This endpoint allows users to update the availability of a specific beer to true or false, while also updating the ABV. ABV's must be sent as a number. An underscore may be included to indicate a decimal (ex. 5_5 will become "5.5% ABV"). Valid requests will receive `Availability and ABV of [name] sucessfully updated!` in response.
+This endpoint allows users to update the ABV of a specific beer. The request object requires `name` and `abv` properties. ABV's must be sent as a number (numbers including a decimal are accepted). Valid requests will receive `ABV of [name] sucessfully updated!` in response.
 
-#### Example Requests:
+#### Example Request:
 
-`api/v1/cerebral_beers/beer/hollow+fang/true/5_5`
-
-`api/v1/cerebral_beers/beer/Remote+Island/False/10_7`
+```
+{
+	"name": "Thornless",
+	"abv": 5.5,
+}
+```
 
 ---
 
 - **PATCH** - Update Availability of a Beer:
   `/api/v1/cerebral_beers/beer/:name/:availability`
 
-This endpoint allows users to update the availability of a specific beer to true or false. Valid requests will receive `Availability of [name] sucessfully updated!` in response.
+This endpoint allows users to update the availability of a specific beer to true or false directly via URL, without the need for a request object. Valid requests will receive `Availability of [name] sucessfully updated!` in response.
 
 #### Example Requests:
 
@@ -106,7 +127,8 @@ This endpoint allows users to delete a beer. Valid deletions will receive `Beer 
 ---
 
 :beer::beer::beer:
-## Styles 
+
+## Styles
 
 - **GET** - Get All Styles: `/api/v1/cerebral_beers/styles`
 
@@ -132,6 +154,7 @@ This endpoint will return an array of all beer styles.
     }
   ]
 ```
+
 ---
 
 - **GET** - Get All Beers of a Style: `/api/v1/cerebral_beers/find_by_style`
@@ -145,23 +168,6 @@ This endpoint will return all beers of a specified style.
 
 ```
 
----
-
-- **GET** - Get All Currently Available Beers: `/api/v1/cerebral_beers/currently_available/:availability`
-
-This endpoint will return all currently available beers.
-
-```
-'/api/v1/cerebral_beers/currently_available/true'
-
-```
-
-All previously available beers may be retieved:
-
-```
-'/api/v1/cerebral_beers/currently_available/false'
-
-```
 ---
 
 - **POST** - Add a Style: `/api/v1/cerebral_beers/styles`

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ This endpoint allows users to update the ABV of a specific beer. The request obj
 
 This endpoint allows users to update the availability of a specific beer to true or false directly via URL, without the need for a request object. Valid requests will receive `Availability of [name] sucessfully updated!` in response.
 
-#### Example Requests:
+#### Example URL's:
 
 `api/v1/cerebral_beers/beer/hollow+fang/true`
 
@@ -120,7 +120,7 @@ This endpoint allows users to update the availability of a specific beer to true
 
 This endpoint allows users to delete a beer. Valid deletions will receive `Beer [name] successfully deleted!` in response.
 
-#### Example Request:
+#### Example URL:
 
 `/api/v1/cerebral_beers/beer/DDH+Strange+Claw`
 
@@ -161,7 +161,7 @@ This endpoint will return an array of all beer styles.
 
 This endpoint will return all beers of a specified style.
 
-#### Example Request:
+#### Example URL:
 
 ```
 '/api/v1/cerebral_beers/find_by_style?style_name=India+Pale+Ale'
@@ -191,6 +191,6 @@ This endpoint allows users to delete a beer style. Valid deletions will receive 
 
 A beer style may not be deleted if there is a beer in the database under that style. These requests will be met with a 405 error and `You're most likely trying to delete a style that has beers attached to it. Please remove those beers first!` in response.
 
-#### Example Request:
+#### Example URL:
 
 `/api/v1/cerebral_beers/styles/India+Pale+Ale`

--- a/db/seeds/prod/cerebral_beers.js
+++ b/db/seeds/prod/cerebral_beers.js
@@ -1,12 +1,11 @@
-const beerData = require("../../../public/cleaner.js");
-const beers = beerData[0];
-const styles = beerData[1];
+const beers = require("../../../public/cleaner.js");
+const styles = require('../../scraped-data/style-descriptions.js');
 
 const createStyles = (knex, style) => {
   return knex("beer_styles")
     .insert(
       {
-        style_name: style.beerStyle,
+        style_name: style.style_name,
         description: style.description
       },
       ["style_name", "id"]

--- a/db/seeds/test/cerebral_beers.js
+++ b/db/seeds/test/cerebral_beers.js
@@ -2,21 +2,21 @@ const beerData = require("../../../public/cleaner.js");
 const beers = [
   {
     name: "TREMBLING GIANT",
-    abv: "6.9%",
+    abv: "6.9% ABV",
     description: "a good beer",
     availability: true,
     beerStyle: "Barrel Aged Biere de Garde"
   },
   {
     name: "GUAVA-ING THROUGH DIMENSIONS",
-    abv: "6.7%",
+    abv: "6.7% ABV",
     description: "a very good beer",
     availability: true,
     beerStyle: "Brettanomyces Saison"
   },
   {
     name: "TANGERINE-ING THROUGH DIMENSIONS",
-    abv: "6.7%",
+    abv: "6.7% ABV",
     description: "an ok beer",
     availability: false,
     beerStyle: "Brettanomyces Saison"

--- a/test/routes.spec.js
+++ b/test/routes.spec.js
@@ -255,36 +255,35 @@ describe("Server file", () => {
     });
 
     describe("patch availibility and abv for /api/v1/cerebral_beers/beer", () => {
-      it("patch request should update availability and abv of beer", done => {
+      it("patch request should update abv of beer", done => {
+        const newAbv = {
+          name: "trembling giant",
+          abv: 110,
+        };
+
         chai
           .request(app)
-          .patch("/api/v1/cerebral_beers/beer/Trembling+Giant/true/55")
+          .patch("/api/v1/cerebral_beers/beer/")
+          .send(newAbv)
           .end((error, response) => {
             expect(response).to.have.status(202);
             expect(response.body).to.equal(
-              `Availibility and ABV of TREMBLING GIANT sucessfully updated!`
-            );
-            done();
-          });
-      });
-
-      it("patch request should fail if availibility not boolean", done => {
-        chai
-          .request(app)
-          .patch("/api/v1/cerebral_beers/beer/Trembling+Giant/nottrue/55")
-          .end((error, response) => {
-            expect(response).to.have.status(404);
-            expect(response.body).to.equal(
-              `Availability must be 'true' or 'false'`
+              `ABV of TREMBLING GIANT sucessfully updated!`
             );
             done();
           });
       });
 
       it("patch request should fail if abv not a number", done => {
+        const newAbv = {
+          name: "trembling giant",
+          abv: 'asdf',
+        };
+        
         chai
           .request(app)
-          .patch("/api/v1/cerebral_beers/beer/Trembling+Giant/true/5asdf5")
+          .patch("/api/v1/cerebral_beers/beer/")
+          .send(newAbv)
           .end((error, response) => {
             expect(response).to.have.status(404);
             expect(response.body).to.equal(
@@ -295,9 +294,15 @@ describe("Server file", () => {
       });
 
       it("patch request should fail if beer not in database", done => {
+        const newAbv = {
+          name: "deep tought",
+          abv: 5.5,
+        };
+        
         chai
           .request(app)
-          .patch("/api/v1/cerebral_beers/beer/Deep+Tought/true/55")
+          .patch("/api/v1/cerebral_beers/beer/")
+          .send(newAbv)
           .end((error, response) => {
             expect(response).to.have.status(404);
             expect(response.body).to.equal(


### PR DESCRIPTION
The /api/v1/cerebral_beers/beer/ patch endpoint now requires a response object with 'name' and 'abv' properties to update ABV. I removed the ability to update availability at the same time; it would've involved some chunky nested if statements and I figured we already have a simple patch endpoint for updating availability on it's own. 

I updated the corresponding tests and readme file as well.