### PR TITLE
Resolve Issue 45: Specific beer by name endpoint

### DIFF
--- a/server.js
+++ b/server.js
@@ -182,6 +182,25 @@ app.patch("/api/v1/cerebral_beers/beer/", (request, response) => {
   }
 });
 
+app.get("/api/v1/cerebral_beers/beer/:name", (request, response) => {
+  let { name } = request.params;
+  name = name.replace(/\+/g, " ").toUpperCase();
+
+  database("beers")
+    .where("name", name)
+    .select()
+    .then(beer => {
+      if (beer === 0) {
+        response.status(404).json(`No beer '${name}' found in database`);
+      } else {
+        response.status(200).json(beer);
+      }
+    })
+    .catch(error => {
+      response.status(500).json({ error: error.message });
+    });
+});
+
 app.delete("/api/v1/cerebral_beers/beer/:name", (request, response) => {
   let { name } = request.params;
   name = name.replace(/\+/g, " ").toUpperCase();

--- a/server.js
+++ b/server.js
@@ -190,7 +190,7 @@ app.get("/api/v1/cerebral_beers/beer/:name", (request, response) => {
     .where("name", name)
     .select()
     .then(beer => {
-      if (beer === 0) {
+      if (beer.length === 0) {
         response.status(404).json(`No beer '${name}' found in database`);
       } else {
         response.status(200).json(beer);

--- a/test/routes.spec.js
+++ b/test/routes.spec.js
@@ -337,8 +337,6 @@ describe("Server file", () => {
 
     it("get request should correctly get individual beer by name", done => {
       const expected = {
-        id: 1,
-        style_id: 1,
         abv: '6.9% ABV',
         description: 'a good beer',
         is_available: true,

--- a/test/routes.spec.js
+++ b/test/routes.spec.js
@@ -355,6 +355,21 @@ describe("Server file", () => {
         })
     })
 
+    it("get request should fail if beer name not found", done => {
+      const url = "/api/v1/cerebral_beers/beer/Trembling+Gigantalore"
+      const expected = "No beer 'TREMBLING GIGANTALORE' found in database"
+
+     chai
+        .request(app)
+        .get(url)
+        .end((error, response) => {
+          console.log(response.body)
+          expect(response).to.have.status(404);
+          expect(response.body).to.equal(expected);
+          done();
+        })
+    })
+
     it("delete request should correctly delete beer", done => {
       chai
         .request(app)

--- a/test/routes.spec.js
+++ b/test/routes.spec.js
@@ -9,20 +9,29 @@ chai.use(chaiHttp);
 
 describe("Server file", () => {
   before(done => {
-    database.migrate
-      .latest()
-      .then(() => done())
-      .catch(error => {
-        throw error;
-      })
-      .done();
-  });
+    database.migrate.rollback()
+    .then(() => database.migrate.latest())
+    .then(() => database.seed.run())
+    .then(() => done())
+    .catch((error) => {
+      throw error
+    })
+    .done()
+  })
 
   beforeEach(done => {
-    database.seed.run().then(() => {
-      done();
+    database.migrate.rollback()
+      .then(() => database.migrate.latest())
+      .then(() => database.seed.run())
+      .then(() => done())
     });
+
+  after(done => {
+    database.migrate.rollback()
+      .then(() => console.log('Testing complete. Db rolled back.'))
+      .then(() => done())
   });
+
 
   it("should return a 404 for a route that does not exist", done => {
     chai
@@ -325,6 +334,26 @@ describe("Server file", () => {
           });
       });
     });
+
+    it("get request should correctly get individual beer by name", done => {
+      const expected = {
+        id: 1,
+        style_id: 1,
+        abv: '6.9% ABV',
+        description: 'a good beer',
+        is_available: true,
+        name: 'TREMBLING GIANT'
+      }
+
+      chai
+        .request(app)
+        .get("/api/v1/cerebral_beers/beer/Trembling+Giant")
+        .end((error, response) => {
+          expect(response).to.have.status(200);
+          expect(response.body[0]).to.include(expected);
+          done();
+        })
+    })
 
     it("delete request should correctly delete beer", done => {
       chai


### PR DESCRIPTION
* Write and pass happy and sad path tests for new `/api/v1/cerebral_beers/beer/:name` endpoint.
* Refactor before(), beforeEach(), and after() blocks at the top of routes.spec.js.

Issue Description:
Create a 'get' endpoint allowing the user to retrieve info on a specific beer by name.

Currently, the API allows users to retrieve a list of all beers, retrieve all beers of a certain style and check the availability of a certain beer. But, there is no option to simply retrieve the information of a specific beer.

The '/api/v1/cerebral_beers/beer' url already has a get endpoint, which returns all beers. A different url must be implemented.