### PR TITLE
Resolve Issue 48 - PATCH specific beer name endpoint

### DIFF
--- a/server.js
+++ b/server.js
@@ -178,9 +178,21 @@ app.post("/api/v1/cerebral_beers/beer", (request, response) => {
 app.patch(
   "/api/v1/cerebral_beers/beer/:name",
   (request, response) => {
-    let newName = request.body.name.toUpperCase();
+    let newName;
     let { name } = request.params;
     let oldName = name.replace(/\+/g, " ").toUpperCase();
+    let missingProperties = [];
+
+    for (let requiredProperty of ["name"]) {
+      if (!request.body[requiredProperty]) {
+        missingProperties = [...missingProperties, requiredProperty];
+        return response
+          .status(422)
+          .send({ error: `Missing Properties ${missingProperties}` });
+      }
+    }
+
+    newName = request.body.name.toUpperCase();
 
     database("beers")
       .where("name", oldName)
@@ -189,7 +201,7 @@ app.patch(
         if (numEdited === 0) {
           response
             .status(404)
-            .json(`Beer '${newName}' does not exist in database.`);
+            .json(`Beer '${oldName}' does not exist in database.`);
         } else {
           response
             .status(202)

--- a/server.js
+++ b/server.js
@@ -176,6 +176,33 @@ app.post("/api/v1/cerebral_beers/beer", (request, response) => {
 });
 
 app.patch(
+  "/api/v1/cerebral_beers/beer/:name",
+  (request, response) => {
+    let newName = request.body.name.toUpperCase();
+    let { name } = request.params;
+    let oldName = name.replace(/\+/g, " ").toUpperCase();
+
+    database("beers")
+      .where("name", oldName)
+      .update({ name: newName })
+      .then(numEdited => {
+        if (numEdited === 0) {
+          response
+            .status(404)
+            .json(`Beer '${newName}' does not exist in database.`);
+        } else {
+          response
+            .status(202)
+            .json(`Name sucessfully updated from ${oldName} to ${newName}!`);
+        }
+      })
+      .catch(error => {
+        response.status(500).json({ error: error.message });
+      });
+  }
+);
+
+app.patch(
   "/api/v1/cerebral_beers/beer/:name/:availability",
   (request, response) => {
     let { name, availability } = request.params;

--- a/test/routes.spec.js
+++ b/test/routes.spec.js
@@ -268,7 +268,6 @@ describe("Server file", () => {
     });
 
     describe("patch name for /api/v1/cerebral_beers/beer", () => {
-
       it("patch request should update name of beer", done => {
         const newName = {name: 'Shaking Elf'}
 
@@ -455,7 +454,6 @@ describe("Server file", () => {
         .request(app)
         .get(url)
         .end((error, response) => {
-          console.log(response.body)
           expect(response).to.have.status(404);
           expect(response.body).to.equal(expected);
           done();

--- a/test/routes.spec.js
+++ b/test/routes.spec.js
@@ -285,27 +285,46 @@ describe("Server file", () => {
           });
       });
 
-      it("patch request should fail if availibility not boolean", done => {
+      it("patch request should fail if beer not in database", done => {
+        const newName = {name: 'Shaking Elf'}
+
         chai
           .request(app)
-          .patch("/api/v1/cerebral_beers/beer/Trembling+Giant/nottrue")
+          .patch("/api/v1/cerebral_beers/beer/Trembling+G")
+          .send(newName)
           .end((error, response) => {
             expect(response).to.have.status(404);
             expect(response.body).to.equal(
-              `Availability must be 'true' or 'false'`
+              `Beer 'TREMBLING G' does not exist in database.`
             );
             done();
           });
       });
 
-      it("patch request should fail if beer not in database", done => {
+      it("patch request should fail if name property missing from request", done => {
+        const newName = {}
+
         chai
           .request(app)
-          .patch("/api/v1/cerebral_beers/beer/Deep+Tought/true")
+          .patch("/api/v1/cerebral_beers/beer/Trembling+G")
+          .send(newName)
           .end((error, response) => {
-            expect(response).to.have.status(404);
-            expect(response.body).to.equal(
-              `Beer 'DEEP TOUGHT' does not exist in database.`
+            expect(response).to.have.status(422);
+            expect(response.body.error).to.equal(
+              'Missing Properties name'
+            );
+            done();
+          });
+      });
+
+      it("patch request should fail if request missing", done => {
+        chai
+          .request(app)
+          .patch("/api/v1/cerebral_beers/beer/Trembling+G")
+          .end((error, response) => {
+            expect(response).to.have.status(422);
+            expect(response.body.error).to.equal(
+              'Missing Properties name'
             );
             done();
           });

--- a/test/routes.spec.js
+++ b/test/routes.spec.js
@@ -267,6 +267,51 @@ describe("Server file", () => {
         });
     });
 
+    describe("patch name for /api/v1/cerebral_beers/beer", () => {
+
+      it("patch request should update name of beer", done => {
+        const newName = {name: 'Shaking Elf'}
+
+        chai
+          .request(app)
+          .patch("/api/v1/cerebral_beers/beer/Trembling+Giant")
+          .send(newName)
+          .end((error, response) => {
+            expect(response).to.have.status(202);
+            expect(response.body).to.equal(
+              `Name sucessfully updated from TREMBLING GIANT to SHAKING ELF!`
+            );
+            done();
+          });
+      });
+
+      it("patch request should fail if availibility not boolean", done => {
+        chai
+          .request(app)
+          .patch("/api/v1/cerebral_beers/beer/Trembling+Giant/nottrue")
+          .end((error, response) => {
+            expect(response).to.have.status(404);
+            expect(response.body).to.equal(
+              `Availability must be 'true' or 'false'`
+            );
+            done();
+          });
+      });
+
+      it("patch request should fail if beer not in database", done => {
+        chai
+          .request(app)
+          .patch("/api/v1/cerebral_beers/beer/Deep+Tought/true")
+          .end((error, response) => {
+            expect(response).to.have.status(404);
+            expect(response.body).to.equal(
+              `Beer 'DEEP TOUGHT' does not exist in database.`
+            );
+            done();
+          });
+      });
+    });
+
     describe("patch availibility for /api/v1/cerebral_beers/beer", () => {
       it("patch request should update availability of beer", done => {
         chai

--- a/test/routes.spec.js
+++ b/test/routes.spec.js
@@ -305,7 +305,7 @@ describe("Server file", () => {
 
         chai
           .request(app)
-          .patch("/api/v1/cerebral_beers/beer/Trembling+G")
+          .patch("/api/v1/cerebral_beers/beer/Trembling+Giant")
           .send(newName)
           .end((error, response) => {
             expect(response).to.have.status(422);
@@ -319,7 +319,7 @@ describe("Server file", () => {
       it("patch request should fail if request missing", done => {
         chai
           .request(app)
-          .patch("/api/v1/cerebral_beers/beer/Trembling+G")
+          .patch("/api/v1/cerebral_beers/beer/Trembling+Giant")
           .end((error, response) => {
             expect(response).to.have.status(422);
             expect(response.body.error).to.equal(


### PR DESCRIPTION
* Creates new PATCH endpoint to edit individual beer name for `/api/v1/cerebral_beers/beer/:name `.
* Write and pass all happy (202) and sad path (404 & two separate 422) tests.

Issue Description: 
Create a patch endpoint which allows the user to update the name of a specific beer.

We all make typos. In the case that a beer is added to the database with a typo in its name, it would be convenient for users to simply update the beer's name without needing to also re-enter the other details.