### PR TITLE
Resolve Issue 46 - GET specific beer style endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1253,9 +1253,9 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
     "core-js": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.0.tgz",
+      "integrity": "sha512-kLRC6ncVpuEW/1kwrOXYX6KQASCVtrh1gQr/UiaVgFlf9WE5Vp+lNe5+h3LuMr5PAucWnnEXwH0nQHRH/gpGtw=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -1739,9 +1739,9 @@
       }
     },
     "fined": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fined/-/fined-1.1.0.tgz",
-      "integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/fined/-/fined-1.1.1.tgz",
+      "integrity": "sha512-jQp949ZmEbiYHk3gkbdtpJ0G1+kgtLQBNdP5edFP7Fh+WAYceLQz6yO1SBj72Xkg8GVyTB3bBzAYrHJVh5Xd5g==",
       "requires": {
         "expand-tilde": "^2.0.2",
         "is-plain-object": "^2.0.3",
@@ -1751,9 +1751,9 @@
       }
     },
     "flagged-respawn": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.0.tgz",
-      "integrity": "sha1-Tnmumy6zi/hrO7Vr8+ClaqX8q9c="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
+      "integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q=="
     },
     "for-in": {
       "version": "1.0.2",
@@ -2958,9 +2958,9 @@
       "integrity": "sha1-Pu/lmX4G2Ugh5NUC5CtqHHP434I="
     },
     "pg-pool": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.4.tgz",
-      "integrity": "sha512-Mi2AsmlFkVMpI28NreaDkz5DkfxLOG16C/HNwi091LDlOiDiQACtAroLxSd1vIS2imBqxdjjO9cQZg2CwsOPbw=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.5.tgz",
+      "integrity": "sha512-T4W9qzP2LjItXuXbW6jgAF2AY0jHp6IoTxRhM3GB7yzfBxzDnA3GCm0sAduzmmiCybMqD0+V1HiqIG5X2YWqlQ=="
     },
     "pg-types": {
       "version": "1.12.1",

--- a/server.js
+++ b/server.js
@@ -17,6 +17,7 @@ app.get("/api/v1/cerebral_beers/styles", (request, response) => {
     });
 });
 
+// Added by Alex & Cole
 app.get("/api/v1/cerebral_beers/styles/:name", (request, response) => {
   let { name } = request.params;
   name = name.replace(/\+/g, " ");
@@ -35,7 +36,7 @@ app.get("/api/v1/cerebral_beers/styles/:name", (request, response) => {
       response.status(500).json({ error: error.message });
     });
 });
-
+//
 
 app.post("/api/v1/cerebral_beers/styles", (request, response) => {
   const newStyle = request.body;

--- a/server.js
+++ b/server.js
@@ -17,6 +17,26 @@ app.get("/api/v1/cerebral_beers/styles", (request, response) => {
     });
 });
 
+app.get("/api/v1/cerebral_beers/styles/:name", (request, response) => {
+  let { name } = request.params;
+  name = name.replace(/\+/g, " ");
+
+  database("beer_styles")
+    .where("style_name", name)
+    .select()
+    .then(style => {
+      if (style === 0) {
+        response.status(404).json(`No style '${name}' found in database`);
+      } else {
+        response.status(200).json(style);
+      }
+    })
+    .catch(error => {
+      response.status(500).json({ error: error.message });
+    });
+});
+
+
 app.post("/api/v1/cerebral_beers/styles", (request, response) => {
   const newStyle = request.body;
   let missingProperties = [];

--- a/server.js
+++ b/server.js
@@ -17,7 +17,6 @@ app.get("/api/v1/cerebral_beers/styles", (request, response) => {
     });
 });
 
-// Added by Alex & Cole
 app.get("/api/v1/cerebral_beers/styles/:name", (request, response) => {
   let { name } = request.params;
   name = name.replace(/\+/g, " ");
@@ -26,7 +25,7 @@ app.get("/api/v1/cerebral_beers/styles/:name", (request, response) => {
     .where("style_name", name)
     .select()
     .then(style => {
-      if (style === 0) {
+      if (style.length === 0) {
         response.status(404).json(`No style '${name}' found in database`);
       } else {
         response.status(200).json(style);
@@ -36,7 +35,6 @@ app.get("/api/v1/cerebral_beers/styles/:name", (request, response) => {
       response.status(500).json({ error: error.message });
     });
 });
-//
 
 app.post("/api/v1/cerebral_beers/styles", (request, response) => {
   const newStyle = request.body;

--- a/test/routes.spec.js
+++ b/test/routes.spec.js
@@ -144,17 +144,16 @@ describe("Server file", () => {
     });
   });
 
-// Added by Alex & Cole
   describe("/api/v1/cerebral_beers/styles/:name", () => {
     it("get request should have a 200 status", done => {
 
       const expected = {
-        description: "German Pilsner, aka Pilsener, aka “Pils,” is the style that became popular after Bohemian Pilsner (made with German lager yeasts) took off. Made with Pilsner malt, the German style could be made with Saaz or any combination of German Hops.",
+        description: "Barrel aged Dark style meant for cellaring",
       }
 
       chai
         .request(app)
-        .get("/api/v1/cerebral_beers/styles/Pilsner")
+        .get("/api/v1/cerebral_beers/styles/Barrel+Aged+Biere+de+Garde")
         .end((error, response) => {
           expect(response).to.have.status(200);
           expect(response.body[0]).to.include(expected)
@@ -163,7 +162,7 @@ describe("Server file", () => {
     });
 
     it("sends 404 for bad path and returns custom text", done => {
-      const expected = "No beer 'Pilsnizzle' found in database"
+      const expected = "No style 'Pilsnizzle' found in database"
       chai
         .request(app)
         .get("/api/v1/cerebral_beers/styles/Pilsnizzle")
@@ -173,9 +172,7 @@ describe("Server file", () => {
           done();
         })
     });
-
   });
-//
 
   describe("/api/v1/cerebral_beers/beer", () => {
     it("get request should have a 200 status", done => {

--- a/test/routes.spec.js
+++ b/test/routes.spec.js
@@ -144,6 +144,39 @@ describe("Server file", () => {
     });
   });
 
+// Added by Alex & Cole
+  describe("/api/v1/cerebral_beers/styles/:name", () => {
+    it("get request should have a 200 status", done => {
+
+      const expected = {
+        description: "German Pilsner, aka Pilsener, aka “Pils,” is the style that became popular after Bohemian Pilsner (made with German lager yeasts) took off. Made with Pilsner malt, the German style could be made with Saaz or any combination of German Hops.",
+      }
+
+      chai
+        .request(app)
+        .get("/api/v1/cerebral_beers/styles/Pilsner")
+        .end((error, response) => {
+          expect(response).to.have.status(200);
+          expect(response.body[0]).to.include(expected)
+          done();
+        });
+    });
+
+    it("sends 404 for bad path and returns custom text", done => {
+      const expected = "No beer 'Pilsnizzle' found in database"
+      chai
+        .request(app)
+        .get("/api/v1/cerebral_beers/styles/Pilsnizzle")
+        .end((error, response) => {
+          expect(response).to.have.status(404);
+          expect(response.body).to.equal(expected);
+          done();
+        })
+    });
+
+  });
+//
+
   describe("/api/v1/cerebral_beers/beer", () => {
     it("get request should have a 200 status", done => {
       chai


### PR DESCRIPTION
* Creates new GeT endpoint to view individual beer styles for `/api/v1/cerebral_beers/styles/:name`.
* Write and pass all happy (200) and sad path (404) tests.

Issue Description: 
Create a 'get' endpoint allowing the user to retrieve the description of a specific beer style.

Currently, the API allows users to retrieve a list of all beer styles or retrieve all beers of a certain style. But, there is no option to simply retrieve the description of a specific style.

The '/api/v1/cerebral_beers/styles' url already has a get endpoint, which returns all beer styles. A different url must be implemented.